### PR TITLE
feat: At mentions and direct messages only

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -202,7 +202,7 @@ max-spelling-suggestions=4
 spelling-dict=en_US
 
 # List of comma separated words that should not be checked.
-spelling-ignore-words=args, bool, yaml, str, config, py, dicts, api, ebr, trackerbot, pragma, commandline, untrack, sqlite, storages, msg, slackbot, filename
+spelling-ignore-words=args, bool, yaml, str, config, py, dicts, api, ebr, trackerbot, pragma, commandline, untrack, sqlite, storages, msg, slackbot, filename, bot's
 
 # A path to a file that contains private dictionary; one word per line.
 spelling-private-dict-file=

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ebr-trackerbot:
 
 Optional settings (also to be included in the ebr-trackerbot section):
 
+* `init_channel`: a message will be posted in this channel at startup, must be set to an existing channel. Default is `#test-slackbot`.
 * `storage_backend`: backend storage medium (memory or sqlite). Default is memory.
 * `sqlite_filename`: sqlite filename path. Default is data.db
 * `slack_message_template`: custom slack message when test failed. Can contain these placeholders: {{test}} - test name, {{count}} - number of failures, {{period}} - time period. Default is an empty string.

--- a/ebr_trackerbot/bot.py
+++ b/ebr_trackerbot/bot.py
@@ -95,8 +95,8 @@ def slack_message_listener(**payload):
     if "text" in data:
         text = re.sub(r"<[^>]+>[ ]+", "", data["text"])
 
-    # Check if the bot has been "at mentioned" (`@slackbot`), if not return)
-    if not re.match(r"^@" + bot_id, text):
+    # Check if the bot has been "at mentioned" (`@slackbot`) or a direct message, if not return)
+    if not re.match(r"^@" + bot_id, text) and not channel_id[0] == "D":
         logging.debug('Message does not "at mention" bot username')
         return
 

--- a/ebr_trackerbot/bot.py
+++ b/ebr_trackerbot/bot.py
@@ -96,7 +96,7 @@ def slack_message_listener(**payload):
         text = re.sub(r"<[^>]+>[ ]+", "", data["text"])
 
     # Check if the bot has been "at mentioned" (`@slackbot`) or a direct message, if not return)
-    if not re.match(r"^@" + bot_id, text) and not channel_id[0] == "D":
+    if not re.match(r"^<@" + bot_id + r">[ ]", text) and not channel_id[0] == "D":
         logging.debug('Message does not "at mention" bot username')
         return
 

--- a/tests/test_ebr_trackerbot.py
+++ b/tests/test_ebr_trackerbot.py
@@ -73,7 +73,7 @@ def test_slack_message_listener_no_user_mentioned(caplog, message_event_payload)
     assert 'Message does not "at mention" bot username' in caplog.text
 
 
-@patch("bot.bot_id", "test_user")
+@patch("bot.bot_user", "test_user")
 @patch("bot.STATE", autospec=False)
 def test_slack_message_listener_user_mentioned(caplog, message_event_payload):
     """
@@ -82,7 +82,7 @@ def test_slack_message_listener_user_mentioned(caplog, message_event_payload):
     payload = message_event_payload
 
     # Provide @mention for message
-    payload["data"]["text"] = "@{user}".format(user=bot.bot_id)
+    payload["data"]["text"] = "<@{user}> bad_command".format(user=bot.bot_user)
     mock_web_client = Mock()
     payload["web_client"] = mock_web_client
 
@@ -97,7 +97,7 @@ def test_slack_message_listener_user_mentioned(caplog, message_event_payload):
     )
 
 
-@patch("bot.bot_id", "test_user")
+@patch("bot.bot_user", "test_user")
 @patch("bot.STATE", autospec=False)
 def test_slack_message_listener_direct_message(caplog, message_event_payload):
     """

--- a/tests/test_ebr_trackerbot.py
+++ b/tests/test_ebr_trackerbot.py
@@ -60,7 +60,7 @@ def test_slack_message_listener_incomplete_payload(caplog):
     """
     payload = {"data": {"type": "message"}}
     with caplog.at_level(logging.DEBUG):
-        bot.slack_message_listener(**payload)
+        bot.slack_message_listener("test_user", **payload)
     assert "Missing one of: channel, ts, user, client_msg_id in slack message" in caplog.text
 
 
@@ -69,24 +69,24 @@ def test_slack_message_listener_no_user_mentioned(caplog, message_event_payload)
     Tests the slack_message_listener to ensure it logs a debug message if there is no bot user "at mentioned" nor has it been direct messaged
     """
     with caplog.at_level(logging.DEBUG):
-        bot.slack_message_listener(**message_event_payload)
+        bot.slack_message_listener("test_user", **message_event_payload)
     assert 'Message does not "at mention" bot username' in caplog.text
 
 
-@patch("bot.bot_user", "test_user")
 @patch("bot.STATE", autospec=False)
 def test_slack_message_listener_user_mentioned(caplog, message_event_payload):
     """
     Tests the slack_message_listener to ensure it processes the command when the slackbot user is "at mentioned"
     """
+    bot_user = "test-user"
     payload = message_event_payload
 
     # Provide @mention for message
-    payload["data"]["text"] = "<@{user}> bad_command".format(user=bot.bot_user)
+    payload["data"]["text"] = "<@{user}> bad_command".format(user=bot_user)
     mock_web_client = Mock()
     payload["web_client"] = mock_web_client
 
-    bot.slack_message_listener(**payload)
+    bot.slack_message_listener(bot_user, **payload)
 
     mock_web_client.chat_postMessage.assert_called_once_with(
         channel=payload["data"]["channel"],
@@ -97,12 +97,12 @@ def test_slack_message_listener_user_mentioned(caplog, message_event_payload):
     )
 
 
-@patch("bot.bot_user", "test_user")
 @patch("bot.STATE", autospec=False)
 def test_slack_message_listener_direct_message(caplog, message_event_payload):
     """
     Tests the slack_message_listener to ensure it processes the command when the slackbot user is sent a DM
     """
+    bot_user = "test_user"
     payload = message_event_payload
 
     # Provide proper channel format
@@ -110,7 +110,7 @@ def test_slack_message_listener_direct_message(caplog, message_event_payload):
     mock_web_client = Mock()
     payload["web_client"] = mock_web_client
 
-    bot.slack_message_listener(**payload)
+    bot.slack_message_listener(bot_user, **payload)
 
     mock_web_client.chat_postMessage.assert_called_once_with(
         channel=payload["data"]["channel"],

--- a/tests/test_ebr_trackerbot.py
+++ b/tests/test_ebr_trackerbot.py
@@ -5,30 +5,93 @@
 
 import sys
 import os
+import pytest
+import logging
+
+from unittest.mock import Mock, patch
 
 sys.path.append("ebr_trackerbot")
 
 import pytest
-from bot import register_command
-from bot import register_storage
-from bot import get_storage
+import bot
 from state import STATE
+
+
+@pytest.fixture
+def message_event_payload():
+    """
+    Provides a message event payload
+    """
+
+    return {
+        "data": {
+            "type": "message",
+            "client_msg_id": "1654564.546",
+            "channel": "test_channel",
+            "user": "test_sending_user",
+            "text": "list",
+            "ts": "1654654.0546",
+        }
+    }
 
 
 def test_register_command():
     """Register command test"""
-    register_command("test", "description", "regex", "callback")
+    bot.register_command("test", "description", "regex", "callback")
     assert "test" in map(lambda x: x["command"], STATE.bot_command)
 
 
 def test_register_storage():
     """Register storage test"""
-    register_storage("test", "save", "load_for_user", "load_all", "delete_for_user", "clean_expired_tracks")
+    bot.register_storage("test", "save", "load_for_user", "load_all", "delete_for_user", "clean_expired_tracks")
     assert "test" in map(lambda x: x["name"], STATE.bot_storage)
 
 
 def test_get_storage():
     """Get storage test"""
-    register_storage("memory", "save", "load_for_user", "load_all", "delete_for_user", "clean_expired_tracks")
-    assert "save" in get_storage()
-    assert "save" == get_storage()["save"]
+    bot.register_storage("memory", "save", "load_for_user", "load_all", "delete_for_user", "clean_expired_tracks")
+    assert "save" in bot.get_storage()
+    assert "save" == bot.get_storage()["save"]
+
+
+def test_slack_message_listener_incomplete_payload(caplog):
+    """
+    Tests the slack_message_listener to ensure it logs a debug message if a field is missing from the data it is passed
+    """
+    payload = {"data": {"type": "message"}}
+    with caplog.at_level(logging.DEBUG):
+        bot.slack_message_listener(**payload)
+    assert "Missing one of: channel, ts, user, client_msg_id in slack message" in caplog.text
+
+
+def test_slack_message_listener_no_user_mentioned(caplog, message_event_payload):
+    """
+    Tests the slack_message_listener to ensure it logs a debug message if there is no bot user "at mentioned"
+    """
+    with caplog.at_level(logging.DEBUG):
+        bot.slack_message_listener(**message_event_payload)
+    assert 'Message does not "at mention" bot username' in caplog.text
+
+
+@patch("bot.bot_id", "test_user")
+@patch("bot.STATE", autospec=False)
+def test_slack_message_listener_user_mentioned(caplog, message_event_payload):
+    """
+    Tests the slack_message_listener to ensure it processes the command when the slackbot user is "at mentioned"
+    """
+    payload = message_event_payload
+
+    # Provide @mention for message
+    payload["data"]["text"] = "@{user}".format(user=bot.bot_id)
+    mock_web_client = Mock()
+    payload["web_client"] = mock_web_client
+
+    bot.slack_message_listener(**payload)
+
+    mock_web_client.chat_postMessage.assert_called_once_with(
+        channel=payload["data"]["channel"],
+        text="Hi <@{user}>! \nI don't understand your command. Please type *help* to see all supported commands\n".format(
+            user=payload["data"]["user"]
+        ),
+        thread_ts=payload["data"]["ts"],
+    )


### PR DESCRIPTION
This updates the slackbot to stop responding anytime it sees one of its commands, but instead to only respond if it has been "at mentioned" or is messaged directly.