### PR TITLE
fix: Fixes issue where __name__ attribute is missing from partial_func

### DIFF
--- a/ebr_trackerbot/bot.py
+++ b/ebr_trackerbot/bot.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 import logging
-import functools
+from functools import partial, update_wrapper
 from vault_anyconfig.vault_anyconfig import VaultAnyConfig
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
@@ -63,6 +63,12 @@ def get_storage():
     if not hasattr(STATE, "bot_storage"):
         STATE.bot_storage = []
     return list(filter(lambda x: x["name"] == get_storage_name(), STATE.bot_storage))[0]
+
+
+def get_partial_function(function, *args, **kwargs):
+    partial_funct = partial(function, *args, **kwargs)
+    update_wrapper(partial_funct, function)
+    return partial_funct
 
 
 def slack_message_listener(bot_user, config_local, **payload):
@@ -202,5 +208,5 @@ def main(config_file, vault_config, vault_creds):
         config["slack_message_template"],
     )
     rtm_client = slack.RTMClient(token=config["slack_token"])
-    rtm_client.on(event="message", callback=functools.partial(slack_message_listener, bot_user, config))
+    rtm_client.on(event="message", callback=get_partial_function(slack_message_listener, bot_user, config))
     rtm_client.start()

--- a/ebr_trackerbot/bot.py
+++ b/ebr_trackerbot/bot.py
@@ -66,6 +66,12 @@ def get_storage():
 
 
 def get_partial_function(function, *args, **kwargs):
+    """
+    Returns a partial function that has already had update_wrapper called on it
+    Args:
+        function: the function to provide a partial for
+    Returns the partial function with updated attributes
+    """
     partial_funct = partial(function, *args, **kwargs)
     update_wrapper(partial_funct, function)
     return partial_funct

--- a/tests/unit/test_ebr_trackerbot.py
+++ b/tests/unit/test_ebr_trackerbot.py
@@ -163,3 +163,11 @@ def test_slack_message_listener_keep_last_10_messages():
         payload["data"]["client_msg_id"] = "123" + str(i)
         bot.slack_message_listener(bot_user, {}, **payload)
     assert len(bot.STATE.last_msgs) == 10
+
+
+def test_slack_message_listener_update_wrapper():
+    """
+    Tests that update_wrapper is correctly preserving __name__
+    """
+
+    assert bot.get_partial_function(bot.slack_message_listener).__name__ == "slack_message_listener"


### PR DESCRIPTION
Handles the fact that partial functions do not have the same `__name__` attribute as the function they wrap unless you add it to them.