### PR TITLE
fix: Place pyodbc requirement into extra_requirements as db_support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY . /code
 WORKDIR /code
 RUN DIST_DIR=$(mktemp -d) && python setup.py sdist --dist-dir $DIST_DIR\
- && pip install $DIST_DIR/*.tar.gz
-
+ && pip install $DIST_DIR/*.tar.gz && pip install pyodbc>=4.0.27
 FROM $PYTHON_BASE
 COPY --from=deploy_builder /opt/venv /opt/venv
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ ebr tracker bot
 
 ## Features
 
+* Store tracking information in ODBC
+
+## Installation
+
+Install with `pip install ebr-trackerbot`.
+
+To install with support for ODBC databases (other than SQLite), use `pip install ebr-trackerbot['db_support']`. This will compile against the odbc
+library, so that must also be installed *including* the development package if you intend to use ODBC. On Ubuntu this can be done with
+`sudo apt-get install unixodbc-dev`.
 
 ## Configuration
 
@@ -51,7 +60,8 @@ empty  file, otherwise see the configuration section above.
 
 * [python3](https://www.python.org/downloads)
 * [pip3](https://pip.pypa.io/en/stable/installing)
-* [virtualenv >= 16.6.0](https://virtualenv.pypa.io/en/latest/installation/)
+* [odbc](https://en.wikipedia.org/wiki/Open_Database_Connectivity) Optional, but required for using any database other than SQLite
+    * Linux: [unixODBC](http://www.unixodbc.org/)
 
 ## Credits
 

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,11 @@ requirements = [
     "pendulum>=2.0.5,<3.0.0",
     "vault-anyconfig>=0.2.2,<0.3.0",
     "PyYAML>=5.1,<6",
-    "pyodbc>=4.0.27,<4.1.0",
 ]
 
-setup_requirements = ["pytest-runner"]
+extra_requirements = {"db_support": ["pyodbc>=4.0.27,<4.1.0"]}
+
+setup_requirements = ["pytest-runner"] + extra_requirements["db_support"]
 
 test_requirements = ["pytest", "pytest-cov", "coverage"]
 
@@ -58,6 +59,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,
+    extra_requirements=extra_requirements,
     url="https://github.com/tomtom-international/ebr-trackerbot",
     version=ebr_trackerbot.__version__,
     zip_safe=False,


### PR DESCRIPTION
This change allows using just SQLite, so that the libraries for ODBC do not have to be installed.