### PR TITLE
feat: Add version output to init message and help command

### DIFF
--- a/ebr_trackerbot/bot.py
+++ b/ebr_trackerbot/bot.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from state import STATE
 from checker import check_tests
+from ebr_trackerbot import __version__ as version
 import slack
 
 config = {}  # pylint: disable=invalid-name
@@ -142,9 +143,11 @@ def id_bot(channel, loop, slack_client):
     message_response = loop.run_until_complete(
         slack_client.chat_postMessage(
             channel=channel,
-            text="""Hi there! I'm the ebr-trackerbot. I can provide automatic tracking of test failures for you.
+            text="""Hi there! I'm the ebr-trackerbot v{version}. I can provide automatic tracking of test failures for you.
 Message me in this channel with an at mention or send me a direct message.
-Use the help command for more info.""",
+Use the help command for more info.""".format(
+                version=version
+            ),
         )
     )
 

--- a/ebr_trackerbot/command/help.py
+++ b/ebr_trackerbot/command/help.py
@@ -2,6 +2,7 @@
 Slack Bot Help Command
 """
 import logging
+from ebr_trackerbot import __version__ as version
 from ebr_trackerbot.bot import register_command
 
 
@@ -16,7 +17,10 @@ def help_command(text, result, payload, config, commands):
         supported_commands += "*" + command["command"] + "* " + command["description"] + "\n"
     response = payload["web_client"].chat_postMessage(
         channel=payload["data"]["channel"],
-        text="Hi <@" + user + ">! \nSupported commands:\n" + supported_commands,
+        text="Hi <@"
+        + user
+        + ">!\nI'm EBR-Trackerbot v{version}\nSupported commands:\n".format(version=version)
+        + supported_commands,
         thread_ts=payload["data"]["ts"],
     )
     if "ok" not in response:

--- a/tests/unit/test_command_help.py
+++ b/tests/unit/test_command_help.py
@@ -3,6 +3,7 @@
 
 """Tests for `ebr_trackerbot` package."""
 
+from ebr_trackerbot import __version__ as version
 from ebr_trackerbot.command.help import help_command
 
 
@@ -21,7 +22,7 @@ def post_message_empty_commands(channel, text, thread_ts):
     """
     Check slack message when there are no registered commands
     """
-    assert text == "Hi <@test>! \nSupported commands:\n"
+    assert text == "Hi <@test>!\nI'm EBR-Trackerbot v{version}\nSupported commands:\n".format(version=version)
     return {"ok": "ok"}
 
 
@@ -40,7 +41,9 @@ def post_message_commands(channel, text, thread_ts):
     """
     Check slack message when there is one command
     """
-    assert text == "Hi <@test>! \nSupported commands:\n*test* some description\n"
+    assert text == "Hi <@test>!\nI'm EBR-Trackerbot v{version}\nSupported commands:\n*test* some description\n".format(
+        version=version
+    )
     return {"ok": "ok"}
 
 


### PR DESCRIPTION
Include the version of the slackbot when providing the init and help messages to make it easy to see which version is running.